### PR TITLE
[CI] Downgrade python to 3.9 for torch on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,10 @@ jobs:
         poetry-version: ["1.2.2", "1.7.1"]
         os: [ubuntu-latest]
         include:
-        - python-version: "3.11"
+        - python-version: "3.9"
           poetry-version: "1.7.1"
           os: macos-latest
+          poetry-install-extra-args: "--compile"
         - python-version: "3.11"
           poetry-version: "1.7.1"
           os: windows-latest
@@ -31,7 +32,6 @@ jobs:
           os: ubuntu-latest
           annotate-errors: true
         - poetry-version: "1.7.1"
-          os: ubuntu-latest
           poetry-install-extra-args: "--compile"
     runs-on: ${{ matrix.os }}
     concurrency:


### PR DESCRIPTION
Following a hint at https://github.com/langchain-ai/langchain/issues/2991

Fixes #10 (I hope)