### PR TITLE
Fix for Python 3.9

### DIFF
--- a/gbmi/exp_max_of_n/train.py
+++ b/gbmi/exp_max_of_n/train.py
@@ -60,7 +60,7 @@ class FullDatasetCfg:
     training_ratio: float = 0.7
 
 
-DatasetCfg = IterableDatasetCfg | FullDatasetCfg
+DatasetCfg = Union[IterableDatasetCfg, FullDatasetCfg]
 
 
 @dataclass


### PR DESCRIPTION
pytest was
[complaining](https://github.com/JasonGross/guarantees-based-mechanistic-interpretability/actions/runs/7607379948/job/20714619678#step:15:25)
```
_______________ ERROR collecting gbmi/exp_max_of_n/train_test.py _______________
gbmi/exp_max_of_n/train_test.py:3: in <module>
    from gbmi.exp_max_of_n.train import MAX_OF_10_CONFIG
gbmi/exp_max_of_n/train.py:63: in <module>
    DatasetCfg = IterableDatasetCfg | FullDatasetCfg
E   TypeError: unsupported operand type(s) for |: 'type' and 'type'
_________________ ERROR collecting gbmi/utils/__init___test.py _________________
gbmi/utils/__init___test.py:3: in <module>
    from gbmi.exp_max_of_n.train import MaxOfN, MAX_OF_10_CONFIG
gbmi/exp_max_of_n/train.py:63: in <module>
    DatasetCfg = IterableDatasetCfg | FullDatasetCfg
E   TypeError: unsupported operand type(s) for |: 'type' and 'type'

```