### PR TITLE
Add --checkpoint-matrix-interp for logging some matrices during training

### DIFF
--- a/gbmi/model.py
+++ b/gbmi/model.py
@@ -99,6 +99,7 @@ class Config(Generic[ExpT]):
     deterministic: bool = True
     seed: int = 123
     batch_size: int = 128
+    validation_batch_size: Optional[int] = None
     train_for: Tuple[int, Literal["steps", "epochs"]] = (15000, "steps")
     log_every_n_steps: int = 10
     validate_every: Optional[Tuple[int, Literal["steps", "epochs"]]] = (10, "steps")
@@ -106,9 +107,18 @@ class Config(Generic[ExpT]):
 
     def __post_init__(self):
         setattr(
-            self, _EXCLUDE, ("log_every_n_steps", "validate_every", "checkpoint_every")
+            self,
+            _EXCLUDE,
+            (
+                "log_every_n_steps",
+                "validate_every",
+                "checkpoint_every",
+                "validation_batch_size",
+            ),
         )
         self.experiment.config_post_init(self)
+        if self.validation_batch_size is None:
+            self.validation_batch_size = self.batch_size
 
     def get_summary_slug(self):
         return self.experiment.get_summary_slug(self)
@@ -158,6 +168,12 @@ class Config(Generic[ExpT]):
             type=int,
             default=None,
             help="Batch size",
+        )
+        parser.add_argument(
+            "--validation-batch-size",
+            type=int,
+            default=None,
+            help="Validation batch size",
         )
         parser.add_argument(
             "--train-for-steps",

--- a/gbmi/utils/__init___test.py
+++ b/gbmi/utils/__init___test.py
@@ -40,6 +40,7 @@ Config(
         ),
         seq_len=10
     ),
+    validation_batch_size=128,
     train_for=(50000, 'steps'),
     validate_every=None
 )""",
@@ -75,6 +76,7 @@ Config(
         ),
         seq_len=10
     ),
+    validation_batch_size=128,
     train_for=(50000, 'steps'),
     validate_every=None
 )""",
@@ -101,6 +103,7 @@ Config(
         ),
         seq_len=10
     ),
+    validation_batch_size=128,
     train_for=(50000, 'steps'),
     validate_every=None
 )""",
@@ -128,6 +131,7 @@ Config(
         ),
         seq_len=10
     ),
+    validation_batch_size=128,
     train_for=(50000, 'steps'),
     validate_every=None
 )""",


### PR DESCRIPTION
tested with
```
time poetry run python -m gbmi.exp_max_of_n.train --max-of 2 --non-deterministic --train-for-epochs 300 --validate-every-epochs 10 --force-adjacent-gap 0,1,2,17 --use-log1p --training-ratio 0.099609375 --weight-decay 1.0 --betas 0.9 0.98 --optimizer AdamW --use-end-of-sequence --batch-size 408 --force train --checkpoint-every-epochs 10 --checkpoint-matrix-interp --validation-batch-size 4096
```

@SoufianeNoubir this should allow you to add plots of various interpretation metrics during training.  Let me know if any of the code needs more explanation.  (Also feel free to click "merge" if you want to build on this)